### PR TITLE
Add `send` and `receive` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ Install this tool using `pip`:
 
 ## Usage
 
+For sending data to an event hub, run:
+
+    eh eventdata send --text '{"message": "Hello Spank"}'
+
+For receiving data to an event hub, run:
+
+    eh eventdata receive
+
+## Configuration
+
+You can set up the connection string and event hub name using the command line options:
+
+    eh eventdata receive --connection-string "Endpoint=.." --name "application-insights"
+
+or the environment variables (or a mix of both):
+
+    export EVENTHUB_CONNECTION_STRING="Endpoint=sb://...="
+    export EVENTHUB_NAME="application-insights"
+
+    eh eventdata receive
+
+    eh eventdata receive --name "another-name"
+
 For help, run:
 
     eventhubs --help

--- a/eventhubs/__main__.py
+++ b/eventhubs/__main__.py
@@ -1,4 +1,4 @@
 from .cli import cli
 
 if __name__ == "__main__":
-    cli()
+    cli(auto_envvar_prefix="EVENTHUB")

--- a/eventhubs/cli.py
+++ b/eventhubs/cli.py
@@ -1,21 +1,65 @@
+import logging
+
 import click
+
+from azure.eventhub import EventHubConsumerClient, EventData
 
 
 @click.group()
 @click.version_option()
-def cli():
-    "CLI tool to send and receive event data from Azure Event Hubs"
-
-
-@cli.command(name="command")
-@click.argument(
-    "example"
+@click.option(
+    "--connection-string",
+    required=True,
+    envvar="EVENTHUB_CONNECTION_STRING",
 )
 @click.option(
-    "-o",
-    "--option",
-    help="An example option",
+    "--consumer-group",
+    required=True,
+    default="$Default",
+    envvar="EVENTHUB_CONSUMER_GROUP",
 )
-def first_command(example, option):
-    "Command description goes here"
-    click.echo("Here is some output")
+@click.option(
+    "--name",
+    required=True,
+    envvar="EVENTHUB_NAME",
+)
+@click.pass_context
+def cli(ctx: click.Context, connection_string: str, consumer_group: str, name: str):
+    "CLI tool to send and receive event data from Azure Event Hubs"
+    ctx.ensure_object(dict)
+    ctx.obj['connection_string'] = connection_string
+    ctx.obj['consumer_group'] = consumer_group
+    ctx.obj['name'] = name    
+
+
+@cli.group()
+def eventdata():
+    return "Here is some output"
+
+
+@eventdata.command(name="receive")
+@click.option(
+    "--starting-position",
+    default="-1",  # "-1" is from the beginning of the partition.
+)
+@click.pass_context
+def receive(ctx: click.Context, starting_position: str):
+    """Receive event data from Azure Event Hubs"""
+
+    client = EventHubConsumerClient.from_connection_string(
+        ctx.obj['connection_string'],
+        ctx.obj['consumer_group'],
+        eventhub_name=ctx.obj['name'],
+    )
+
+    def on_event(partition_context, event: EventData):
+        print(f"Received event from partition {partition_context.partition_id}: {event.body_as_str()}")
+        partition_context.update_checkpoint(event)
+
+    with client:
+        print("Receiving events from Azure Event Hubs")
+        client.receive(
+            on_event=on_event,
+            starting_position=starting_position,
+        )    
+

--- a/eventhubs/cli.py
+++ b/eventhubs/cli.py
@@ -2,7 +2,7 @@ import logging
 
 import click
 
-from azure.eventhub import EventHubConsumerClient, EventData
+from azure.eventhub import EventHubConsumerClient, EventHubProducerClient, EventData
 
 
 @click.group()
@@ -63,3 +63,26 @@ def receive(ctx: click.Context, starting_position: str):
             starting_position=starting_position,
         )    
 
+
+@eventdata.command(name="send")
+@click.option(
+    "--text",
+    required=True,
+)
+@click.pass_context
+def send(ctx: click.Context, text: str):
+    """Send event data to Azure Event Hubs"""
+
+    print("Creating EventHubProducerClient")
+    client = EventHubProducerClient.from_connection_string(
+        ctx.obj['connection_string'],
+        eventhub_name=ctx.obj['name'],
+    )
+
+    # print(f"Sending event data to Azure Event Hubs: {text}")
+    # event_data_batch.add(EventData(text))
+
+    print("Sending event data to Azure Event Hubs")
+    with client:
+        # client.send_batch(event_data_batch)
+        client.send_event(EventData(text))

--- a/eventhubs/cli.py
+++ b/eventhubs/cli.py
@@ -1,5 +1,3 @@
-import logging
-
 import click
 
 from azure.eventhub import EventHubConsumerClient, EventHubProducerClient, EventData
@@ -34,7 +32,7 @@ def cli(ctx: click.Context, connection_string: str, consumer_group: str, name: s
 
 @cli.group()
 def eventdata():
-    return "Here is some output"
+    return "Event data commands"
 
 
 @eventdata.command(name="receive")
@@ -71,18 +69,13 @@ def receive(ctx: click.Context, starting_position: str):
 )
 @click.pass_context
 def send(ctx: click.Context, text: str):
-    """Send event data to Azure Event Hubs"""
+    """Send a single event data to Azure Event Hubs"""
 
-    print("Creating EventHubProducerClient")
     client = EventHubProducerClient.from_connection_string(
         ctx.obj['connection_string'],
         eventhub_name=ctx.obj['name'],
     )
 
-    # print(f"Sending event data to Azure Event Hubs: {text}")
-    # event_data_batch.add(EventData(text))
-
     print("Sending event data to Azure Event Hubs")
     with client:
-        # client.send_batch(event_data_batch)
         client.send_event(EventData(text))

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ setup(
         [console_scripts]
         eh=eventhubs.cli:cli
     """,
-    install_requires=["click"],
+    install_requires=[
+        "click",
+        "azure-eventhub==5.11.1",
+    ],
     extras_require={
         "test": ["pytest"]
     },


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I need a simple CLI tool to:

- receive from an event hub and print it to the stdout.
- send data to and event hub

The can help a lot on development and troubleshooting of event hub related apps.

### Change description
<!-- What does your code do? -->

Add a simple implementation of a `receive` and `send` commands using https://devblogs.microsoft.com/azure-sdk/announcing-the-stable-release-of-the-python-event-hubs-client-library-using-pure-python-amqp-stack/ as starting point.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

Relates: zmoog/public-notes#25

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.