### PR TITLE
Send multiple event in batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,29 @@ Install this tool using `pip`:
 
 ## Usage
 
-For sending data to an event hub, run:
-
-    eh eventdata send --text '{"message": "Hello Spank"}'
+### Receiving
 
 For receiving data to an event hub, run:
 
     eh eventdata receive
+
+### Sending
+
+For sending a single event to an event hub, run:
+
+    eh eventdata send --text '{"message": "Hello Spank"}'
+
+You can also send multiple events in a batch by using `--text` more than once:
+
+    eh eventdata send --text '{"message": "Hello Spank"}' --text '{"message": "Hello Spank (yes, again)"}'
+
+For sending the lines in a text files as event, run:
+
+    eh eventdata send --lines-from-text-file multiline.txt
+
+For sending the lines from `stdin` as event, run:
+
+    cat multiline.txt | eh eventdata send  
 
 ## Configuration
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

We want to send more than one event with a single command. 

For example, given the `multiline.txt` file contains multiple lines:

```shell
$ cat multiline.txt
line 1
line 2
line 3
```

We want to send all of these lines to event hub in a single batch using one of the following options:

```shell
# reading the lines from a file:
$ eh eventdata send --lines-from-text-file multiline.txt
line 1
line 2
line 3

# or using the standard input:
$ cat multiline.txt | eh eventdata send
line 1
line 2
line 3
```

### Change description
<!-- What does your code do? -->

Switch from using `send_event(event)` to `send_batch(batch)` on `EventHubProducerClient`.

We currently support `str`-based inputs only, so no `bytes` content at the moment.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

- Closes #2 

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.