### PR TITLE
Enable verbose option on all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ or the environment variables (or a mix of both):
 
     eh eventdata receive --name "another-name"
 
+Defaults to printing the message payload only, so it is easier to combine output with other tools, like `jq`:
+
+    $ eh eventdata receive | jq '.records[].tenantId' 
+    "1de2b364-21e1-4866-bb46-7804f17c417d"
+    "1de2b364-21e1-4866-bb46-7804f17c417d"
+    "1de2b364-21e1-4866-bb46-7804f17c417d"
+
+But you can still turn on verbose and get more information about what's going on:
+
+    $ eh --verbose eventdata receive
+    Receiving events from mbranca
+    Received event from partition 0: {"records": [{....
+
 For help, run:
 
     eventhubs --help


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Defaults to printing the message payload only, so it is easier to combine output with other tools, like `jq`:

```shell
$ eh eventdata receive | jq '.records[].tenantId' 
"1de2b364-21e1-4866-bb46-7804f17c417d"
"1de2b364-21e1-4866-bb46-7804f17c417d"
"1de2b364-21e1-4866-bb46-7804f17c417d"
```

But you can still turn on verbose and get more information about what's going on:

```shell
$ eh --verbose eventdata receive
Receiving events from mbranca
Received event from partition 0: {"records": [{....
```

### Change description
<!-- What does your code do? -->

Add a couple of `if`s.

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [x] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.