### PR TITLE
Split send into send-event and send-batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ For receiving data to an event hub, run:
 
 For sending a single event to an event hub, run:
 
-    eh eventdata send --text '{"message": "Hello Spank"}'
+    eh eventdata send-event --text '{"message": "Hello Spank"}'
 
-You can also send multiple events in a batch by using `--text` more than once:
+You can also send multiple events in a batch by using the `send-batch` command with `--text` multiple times:
 
-    eh eventdata send --text '{"message": "Hello Spank"}' --text '{"message": "Hello Spank (yes, again)"}'
+    eh eventdata send-batch --text '{"message": "Hello Spank"}' --text '{"message": "Hello Spank (yes, again)"}'
 
 For sending the lines in a text files as event, run:
 
-    eh eventdata send --lines-from-text-file multiline.txt
+    eh eventdata send-batch --lines-from-text-file multiline.txt
 
 For sending the lines from `stdin` as event, run:
 
-    cat multiline.txt | eh eventdata send  
+    cat multiline.txt | eh eventdata send-batch  
 
-## Configuration
+### Configuration
 
 You can set up the connection string and event hub name using the command line options:
 

--- a/eventhubs/cli.py
+++ b/eventhubs/cli.py
@@ -170,8 +170,6 @@ def send_batch(ctx: click.Context, text: List[str], lines_from_text_file: Union[
         for i in range(0, len(events), batch_size):
             batch = producer.create_batch()
             for event in events[i:i+batch_size]:
-                # if ctx.obj['verbose']:
-                #     print(f"adding {event}")
                 try:
                     batch.add(EventData(event))
                 except ValueError as e:
@@ -184,7 +182,6 @@ def send_batch(ctx: click.Context, text: List[str], lines_from_text_file: Union[
             if ctx.obj['verbose']:
                 print(f"sending batch of {len(batch)} events")
             
-            # producer.send_batch(batch, partition_key="whatever")
             producer.send_batch(batch)
 
             if ctx.obj['verbose']:


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I want better control over sending options:

- I want to use a `--partition-key` when sending a single event.
- I want to use a `--batch-size` when sending multiple events.

### Change description
<!-- What does your code do? -->

This PR splits the `send` command into two specialized commands:

- `send-event` sends only one event, allowing using the provided `--partition-key` option.
- `send-batch` sends all events in one of multiple batches using the provided `--batch-size` option.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] Docs are updated (at least the `README.md`, if needed).
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.