### PR TITLE
Release v0.5

### DIFF
--- a/MIGRATION-0.4-to-0.5.md
+++ b/MIGRATION-0.4-to-0.5.md
@@ -1,0 +1,152 @@
+# Migration guide: v0.4 to v0.5
+
+This guide covers all breaking changes and new features introduced in v0.5.
+
+## Breaking changes
+
+### Command group renamed: `eventdata` → `events`
+
+The `eventdata` subcommand group has been renamed to `events`.
+
+```diff
+- eh eventdata receive
++ eh events receive
+```
+
+```diff
+- eh eventdata send-batch --text '{"msg": "hi"}'
++ eh events send-batch --text '{"msg": "hi"}'
+```
+
+### Send command renamed: `send-event` → `send`
+
+The `send-event` command is now simply `send`.
+
+```diff
+- eh eventdata send-event --text '{"msg": "hello"}'
++ eh events send --text '{"msg": "hello"}'
+```
+
+### `--connection-string` is no longer required
+
+The `--connection-string` flag (and `EVENTHUB_CONNECTION_STRING` env var) is still supported, but it is no longer mandatory. v0.5 introduces token-based authentication as an alternative. If you rely on connection strings, your existing setup continues to work—you just no longer get an error when the flag is omitted (provided a config context supplies the value instead).
+
+### `--name` is no longer positionally required
+
+`--name` is still needed, but it can now come from a config context instead of always being passed on the command line or via `EVENTHUB_NAME`.
+
+## New features
+
+### Token-based authentication (Azure Identity)
+
+You can now authenticate without a connection string by using `--fully-qualified-namespace` and `--credential`:
+
+```bash
+eh --fully-qualified-namespace mynamespace.servicebus.windows.net \
+   --credential default \
+   events receive
+```
+
+Supported credential types:
+
+| Value              | Azure Identity class         |
+|--------------------|------------------------------|
+| `default`          | `DefaultAzureCredential`     |
+| `azurecli`         | `AzureCliCredential`         |
+| `environment`      | `EnvironmentCredential`      |
+| `managedidentity`  | `ManagedIdentityCredential`  |
+
+The corresponding env vars are `EVENTHUB_FULLY_QUALIFIED_NAMESPACE` and `EVENTHUB_CREDENTIAL`.
+
+> **Note:** `--connection-string` and `--fully-qualified-namespace` are mutually exclusive.
+
+### Configuration file and named contexts
+
+v0.5 adds a YAML config file (`~/.config/eventhubs/config.yaml`) with kubectl-style named contexts, so you no longer need to pass connection details on every invocation.
+
+#### Create a context
+
+```bash
+eh config set-context prod \
+  --connection-string "Endpoint=sb://..." \
+  --eventhub-name my-hub \
+  --consumer-group "\$Default"
+```
+
+Or with token-based auth:
+
+```bash
+eh config set-context dev \
+  --fully-qualified-namespace mynamespace.servicebus.windows.net \
+  --credential azurecli \
+  --eventhub-name my-hub
+```
+
+#### Switch contexts
+
+```bash
+eh config use-context prod
+```
+
+#### List and inspect contexts
+
+```bash
+eh config get-contexts       # list all contexts (* marks the active one)
+eh config current-context    # print the active context name
+```
+
+#### Delete a context
+
+```bash
+eh config delete-context old-env
+```
+
+#### Use a one-off context without switching
+
+```bash
+eh --context dev events receive
+```
+
+#### Precedence
+
+Settings are resolved in this order (highest wins):
+
+1. CLI flags / environment variables
+2. Named context selected with `--context`
+3. `current-context` from the config file
+
+This means you can set defaults in a context and override individual values on the command line:
+
+```bash
+eh config use-context prod
+eh events receive                      # uses everything from "prod"
+eh events receive --name other-hub     # overrides just the hub name
+```
+
+#### Custom config file location
+
+Set the `EVENTHUB_CONFIG` env var to use a config file in a non-default location:
+
+```bash
+export EVENTHUB_CONFIG=/path/to/my/config.yaml
+```
+
+### New dependencies
+
+v0.5 adds two new dependencies:
+
+- `azure-identity` — required for token-based authentication
+- `pyyaml` — required for the config file
+
+Both are installed automatically when you upgrade:
+
+```bash
+pip install --upgrade eventhubs
+```
+
+## Quick migration checklist
+
+1. Replace `eventdata` with `events` in all scripts and aliases.
+2. Replace `send-event` with `send`.
+3. (Optional) Set up a config context to stop passing `--connection-string` and `--name` on every call.
+4. (Optional) Switch from connection strings to token-based auth for better security.

--- a/eventhubs/auth.py
+++ b/eventhubs/auth.py
@@ -1,0 +1,60 @@
+"""Factory functions to build Event Hub clients from resolved settings."""
+
+from typing import Any, Dict
+
+from azure.eventhub import EventHubConsumerClient, EventHubProducerClient
+
+
+def _make_credential(credential_type: str):
+    """Create an azure-identity credential from a type name."""
+    from azure.identity import (
+        AzureCliCredential,
+        DefaultAzureCredential,
+        EnvironmentCredential,
+        ManagedIdentityCredential,
+    )
+
+    credentials = {
+        "default": DefaultAzureCredential,
+        "azurecli": AzureCliCredential,
+        "environment": EnvironmentCredential,
+        "managedidentity": ManagedIdentityCredential,
+    }
+
+    cls = credentials.get(credential_type)
+    if cls is None:
+        raise ValueError(
+            f"unknown credential type '{credential_type}', "
+            f"must be one of: {', '.join(credentials)}"
+        )
+    return cls()
+
+
+def make_consumer(settings: Dict[str, Any]) -> EventHubConsumerClient:
+    if settings.get("connection_string"):
+        return EventHubConsumerClient.from_connection_string(
+            settings["connection_string"],
+            settings["consumer_group"],
+            eventhub_name=settings["name"],
+        )
+
+    return EventHubConsumerClient(
+        fully_qualified_namespace=settings["fully_qualified_namespace"],
+        eventhub_name=settings["name"],
+        consumer_group=settings["consumer_group"],
+        credential=_make_credential(settings["credential"]),
+    )
+
+
+def make_producer(settings: Dict[str, Any]) -> EventHubProducerClient:
+    if settings.get("connection_string"):
+        return EventHubProducerClient.from_connection_string(
+            settings["connection_string"],
+            eventhub_name=settings["name"],
+        )
+
+    return EventHubProducerClient(
+        fully_qualified_namespace=settings["fully_qualified_namespace"],
+        eventhub_name=settings["name"],
+        credential=_make_credential(settings["credential"]),
+    )

--- a/eventhubs/cli.py
+++ b/eventhubs/cli.py
@@ -1,100 +1,243 @@
+import signal
 import sys
+import threading
 from typing import List, Optional, TextIO, Union
 
 import click
 
-from azure.eventhub import EventHubConsumerClient, EventHubProducerClient, EventData
+from azure.eventhub import EventData
 
+from eventhubs.auth import make_consumer, make_producer
+from eventhubs.config import (
+    VALID_CREDENTIAL_TYPES,
+    load_config,
+    save_config,
+    get_current_context,
+    get_context,
+)
+from eventhubs import config as config_module
+
+
+def _resolve_settings(ctx: click.Context) -> dict:
+    """Merge config-file context with CLI flags/env vars.
+
+    Precedence (highest wins):
+      1. CLI flags / env vars (if explicitly provided)
+      2. Named context (--context flag)
+      3. current-context from config file
+    """
+    cfg = load_config()
+
+    context_name = ctx.params.get("context")
+    if context_name:
+        context_values = get_context(cfg, context_name)
+        if context_values is None:
+            raise click.ClickException(f"context '{context_name}' not found in config")
+    else:
+        context_values = get_current_context(cfg) or {}
+
+    key_map = {
+        "connection-string": "connection_string",
+        "fully-qualified-namespace": "fully_qualified_namespace",
+        "credential": "credential",
+        "eventhub-name": "name",
+        "consumer-group": "consumer_group",
+    }
+
+    settings = {}
+    for config_key, settings_key in key_map.items():
+        settings[settings_key] = context_values.get(config_key)
+
+    cli_source = ctx.get_parameter_source
+    params = ctx.params
+    overrides = {
+        "connection_string": "connection_string",
+        "fully_qualified_namespace": "fully_qualified_namespace",
+        "credential": "credential",
+        "name": "name",
+        "consumer_group": "consumer_group",
+    }
+    for param_name, settings_key in overrides.items():
+        source = cli_source(param_name)
+        if source in (
+            click.core.ParameterSource.COMMANDLINE,
+            click.core.ParameterSource.ENVIRONMENT,
+        ):
+            settings[settings_key] = params[param_name]
+        elif source == click.core.ParameterSource.DEFAULT and settings.get(settings_key) is None:
+            settings[settings_key] = params[param_name]
+
+    return settings
+
+
+def _validate_settings(settings: dict) -> None:
+    has_conn_str = bool(settings.get("connection_string"))
+    has_fqns = bool(settings.get("fully_qualified_namespace"))
+    has_credential = bool(settings.get("credential"))
+
+    if has_conn_str and has_fqns:
+        raise click.ClickException(
+            "--connection-string and --fully-qualified-namespace are mutually exclusive"
+        )
+
+    if not has_conn_str and not has_fqns:
+        raise click.ClickException(
+            "either --connection-string or --fully-qualified-namespace is required "
+            "(via flag, env var, or config context)"
+        )
+
+    if has_fqns and not has_credential:
+        raise click.ClickException(
+            "--credential is required when using --fully-qualified-namespace"
+        )
+
+    if not settings.get("name"):
+        raise click.ClickException(
+            "--name is required (via flag, env var, or config context)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Root CLI group
+# ---------------------------------------------------------------------------
 
 @click.group()
 @click.version_option()
 @click.option(
     "--connection-string",
-    required=True,
+    required=False,
     envvar="EVENTHUB_CONNECTION_STRING",
+    default=None,
+    help="Event Hub connection string.",
+)
+@click.option(
+    "--fully-qualified-namespace",
+    required=False,
+    envvar="EVENTHUB_FULLY_QUALIFIED_NAMESPACE",
+    default=None,
+    help="Event Hub namespace (e.g. mynamespace.servicebus.windows.net).",
+)
+@click.option(
+    "--credential",
+    required=False,
+    envvar="EVENTHUB_CREDENTIAL",
+    default=None,
+    type=click.Choice(VALID_CREDENTIAL_TYPES, case_sensitive=False),
+    help="Credential type for token-based auth.",
 )
 @click.option(
     "--consumer-group",
-    required=True,
+    required=False,
     default="$Default",
     envvar="EVENTHUB_CONSUMER_GROUP",
 )
 @click.option(
     "--name",
-    required=True,
+    required=False,
+    default=None,
     envvar="EVENTHUB_NAME",
+    help="Event Hub name.",
+)
+@click.option(
+    "--context",
+    "context",
+    required=False,
+    default=None,
+    help="Use a named context from the config file.",
 )
 @click.option(
     "-v",
     "--verbose",
     is_flag=True,
-    help="Enables verbose mode",
+    help="Enables verbose mode.",
     default=False,
     envvar="EVENTHUB_VERBOSE",
 )
 @click.pass_context
-def cli(ctx: click.Context, connection_string: str, consumer_group: str, name: str, verbose: bool):
-    """CLI tool to send and receive event data from Azure Event Hubs"""
+def cli(
+    ctx: click.Context,
+    connection_string: Optional[str],
+    fully_qualified_namespace: Optional[str],
+    credential: Optional[str],
+    consumer_group: str,
+    name: Optional[str],
+    context: Optional[str],
+    verbose: bool,
+):
+    """CLI tool to send and receive event data from Azure Event Hubs."""
     ctx.ensure_object(dict)
-    ctx.obj['connection_string'] = connection_string
-    ctx.obj['consumer_group'] = consumer_group
-    ctx.obj['name'] = name
-    ctx.obj['verbose'] = verbose
+    ctx.obj["verbose"] = verbose
 
+    # Config subcommands and --help don't need connection settings.
+    if ctx.invoked_subcommand == "config" or ctx.resilient_parsing:
+        return
+
+    # Defer resolution when a subcommand will handle --help itself.
+    if any(arg in ("--help", "-h") for arg in sys.argv[1:]):
+        return
+
+    settings = _resolve_settings(ctx)
+    _validate_settings(settings)
+
+    ctx.obj.update(settings)
+
+
+# ---------------------------------------------------------------------------
+# events command group
+# ---------------------------------------------------------------------------
 
 @cli.group()
-def eventdata():
-    return "Event data commands"
+def events():
+    """Send and receive events."""
 
 
-@eventdata.command(name="receive")
+@events.command(name="receive")
 @click.option(
     "--starting-position",
-    default="-1",  # "-1" is from the beginning of the partition.
+    default="-1",
 )
 @click.pass_context
 def receive(ctx: click.Context, starting_position: str):
-    """Receive event data from Azure Event Hubs"""
-
-    consumer = EventHubConsumerClient.from_connection_string(
-        ctx.obj['connection_string'],
-        ctx.obj['consumer_group'],
-        eventhub_name=ctx.obj['name'],
-    )
+    """Receive event data from Azure Event Hubs."""
+    consumer = make_consumer(ctx.obj)
 
     def on_event(partition_context, event: EventData):
-        if ctx.obj['verbose']:
-            print(f"Received event from partition {partition_context.partition_id}: {event.body_as_str()}")
+        if event is None:
+            return
+        if ctx.obj["verbose"]:
+            sys.stdout.write(f"Received event from partition {partition_context.partition_id}: {event.body_as_str()}\n")
         else:
-            print(event.body_as_str())
+            sys.stdout.write(event.body_as_str() + "\n")
+        sys.stdout.flush()
         partition_context.update_checkpoint(event)
 
+    def on_error(partition_context, error: Exception):
+        sys.stderr.write(f"Error on partition {partition_context.partition_id}: {error}\n")
+        sys.stderr.flush()
+
     with consumer:
-        if ctx.obj['verbose']:
+        if ctx.obj["verbose"]:
             print(f"Receiving events from {ctx.obj['name']}")
         consumer.receive(
             on_event=on_event,
+            on_error=on_error,
             starting_position=starting_position,
-        )    
+            max_wait_time=5,
+        )
+
+        stop = threading.Event()
+        signal.signal(signal.SIGINT, lambda *_: stop.set())
+        signal.signal(signal.SIGTERM, lambda *_: stop.set())
+        stop.wait()
 
 
-@eventdata.command(name="send-event")
-@click.option(
-    "--text",
-    required=False
-)
-@click.option(
-    "--partition-key",
-    required=False
-)
+@events.command(name="send")
+@click.option("--text", required=False)
+@click.option("--partition-key", required=False)
 @click.pass_context
-def send_event(ctx: click.Context, text: Union[str, TextIO], partition_key: Optional[str] = None):
-    """Send a single event data to Azure Event Hubs"""
-
-    producer = EventHubProducerClient.from_connection_string(
-        ctx.obj['connection_string'],
-        eventhub_name=ctx.obj['name'],
-    )
+def send(ctx: click.Context, text: Union[str, TextIO], partition_key: Optional[str] = None):
+    """Send a single event."""
+    producer = make_producer(ctx.obj)
 
     if text:
         event = text
@@ -102,53 +245,35 @@ def send_event(ctx: click.Context, text: Union[str, TextIO], partition_key: Opti
         event = sys.stdin.read()
 
     if not isinstance(event, str):
-        # supporting only str-based input, we'll
-        # evaluate bytes later on
         raise TypeError(f"only 'str' is supported (found: {type(event)})")
 
     with producer:
-        if ctx.obj['verbose']:
+        if ctx.obj["verbose"]:
             print(f"Sending one event to {ctx.obj['name']}")
 
         producer.send_event(EventData(event), partition_key=partition_key)
 
-        if ctx.obj['verbose']:
-            print(f"event sent successfully")
+        if ctx.obj["verbose"]:
+            print("event sent successfully")
 
 
-@eventdata.command(name="send-batch")
-@click.option(
-    "--text",
-    required=False,
-    multiple=True,
-    default=None,
-)
+@events.command(name="send-batch")
+@click.option("--text", required=False, multiple=True, default=None)
 @click.option(
     "--lines-from-text-file",
     help="Text file to read lines from. If not provided, stdin will be used.",
     type=click.Path(file_okay=True, dir_okay=False, allow_dash=True),
     default="-",
 )
-@click.option(
-    "--batch-size",
-    default=10,
-)
+@click.option("--batch-size", default=10)
 @click.pass_context
 def send_batch(ctx: click.Context, text: List[str], lines_from_text_file: Union[str, TextIO], batch_size: int):
-    """Send a batch of event data to Azure Event Hubs"""
-
-    producer = EventHubProducerClient.from_connection_string(
-        ctx.obj['connection_string'],
-        eventhub_name=ctx.obj['name'],
-    )
+    """Send a batch of event data to Azure Event Hubs."""
+    producer = make_producer(ctx.obj)
 
     if text:
-        # text contains a list of events since the
-        # option is defined as `multiple=True`
         events = text
     else:
-        # we look for a str to split in line from stdin or
-        # a text file
         if lines_from_text_file in ("-", "stdin"):
             content = sys.stdin.read()
         else:
@@ -156,33 +281,128 @@ def send_batch(ctx: click.Context, text: List[str], lines_from_text_file: Union[
                 content = f.read()
 
         if not isinstance(content, str):
-            # supporting only str-based input, we'll
-            # evaluate bytes later on
             raise TypeError(f"only 'str' is supported (found: {type(content)})")
 
         events = content.splitlines()
 
     with producer:
-        if ctx.obj['verbose']:
+        if ctx.obj["verbose"]:
             print(f"Sending {len(events)} events to {ctx.obj['name']}")
 
-        # send the events in batches of `batch_size`
         for i in range(0, len(events), batch_size):
             batch = producer.create_batch()
-            for event in events[i:i+batch_size]:
+            for event in events[i : i + batch_size]:
                 try:
                     batch.add(EventData(event))
-                except ValueError as e:
-                    # if the batch is full, we send the
-                    # current one and the create a brand
-                    # new one for the remaining events
-                    if ctx.obj['verbose']:
+                except ValueError:
+                    if ctx.obj["verbose"]:
                         print("Event data batch is full ({} events).".format(len(batch)))
-            
-            if ctx.obj['verbose']:
+
+            if ctx.obj["verbose"]:
                 print(f"sending batch of {len(batch)} events")
-            
+
             producer.send_batch(batch)
 
-            if ctx.obj['verbose']:
-                print(f"batch sent successfully")
+            if ctx.obj["verbose"]:
+                print("batch sent successfully")
+
+
+# ---------------------------------------------------------------------------
+# config command group
+# ---------------------------------------------------------------------------
+
+@cli.group(name="config")
+def config_group():
+    """Manage CLI configuration and contexts."""
+
+
+@config_group.command(name="get-contexts")
+def config_get_contexts():
+    """List all configured contexts."""
+    cfg = load_config()
+    contexts = cfg.get("contexts", {})
+    current = cfg.get("current-context", "")
+
+    if not contexts:
+        click.echo("No contexts configured.")
+        return
+
+    for name, values in contexts.items():
+        marker = "*" if name == current else " "
+        if values.get("connection-string"):
+            auth = "connection-string"
+        elif values.get("fully-qualified-namespace"):
+            auth = f"{values.get('credential', '?')}@{values['fully-qualified-namespace']}"
+        else:
+            auth = "incomplete"
+        click.echo(f"{marker} {name:20s}  {values.get('eventhub-name', ''):20s}  {auth}")
+
+
+@config_group.command(name="current-context")
+def config_current_context():
+    """Show the current context name."""
+    cfg = load_config()
+    current = cfg.get("current-context", "")
+    if not current:
+        click.echo("No current context is set.")
+    else:
+        click.echo(current)
+
+
+@config_group.command(name="use-context")
+@click.argument("name")
+def config_use_context(name: str):
+    """Switch to a different context."""
+    cfg = load_config()
+    try:
+        config_module.use_context(cfg, name)
+    except ValueError as e:
+        raise click.ClickException(str(e))
+    save_config(cfg)
+    click.echo(f"Switched to context '{name}'.")
+
+
+@config_group.command(name="set-context")
+@click.argument("name")
+@click.option("--connection-string", default=None)
+@click.option("--fully-qualified-namespace", default=None)
+@click.option(
+    "--credential",
+    default=None,
+    type=click.Choice(VALID_CREDENTIAL_TYPES, case_sensitive=False),
+)
+@click.option("--eventhub-name", default=None)
+@click.option("--consumer-group", default=None)
+def config_set_context(
+    name: str,
+    connection_string: Optional[str],
+    fully_qualified_namespace: Optional[str],
+    credential: Optional[str],
+    eventhub_name: Optional[str],
+    consumer_group: Optional[str],
+):
+    """Create or update a named context."""
+    cfg = load_config()
+    values = {
+        "connection-string": connection_string,
+        "fully-qualified-namespace": fully_qualified_namespace,
+        "credential": credential,
+        "eventhub-name": eventhub_name,
+        "consumer-group": consumer_group,
+    }
+    config_module.set_context(cfg, name, values)
+    save_config(cfg)
+    click.echo(f"Context '{name}' updated.")
+
+
+@config_group.command(name="delete-context")
+@click.argument("name")
+def config_delete_context(name: str):
+    """Delete a named context."""
+    cfg = load_config()
+    try:
+        config_module.delete_context(cfg, name)
+    except ValueError as e:
+        raise click.ClickException(str(e))
+    save_config(cfg)
+    click.echo(f"Context '{name}' deleted.")

--- a/eventhubs/config.py
+++ b/eventhubs/config.py
@@ -1,0 +1,74 @@
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+
+DEFAULT_CONFIG_DIR = os.path.join(Path.home(), ".config", "eventhubs")
+DEFAULT_CONFIG_PATH = os.path.join(DEFAULT_CONFIG_DIR, "config.yaml")
+
+VALID_CREDENTIAL_TYPES = ("default", "azurecli", "environment", "managedidentity")
+
+
+def get_config_path() -> str:
+    return os.environ.get("EVENTHUB_CONFIG", DEFAULT_CONFIG_PATH)
+
+
+def load_config() -> Dict[str, Any]:
+    path = get_config_path()
+    if not os.path.exists(path):
+        return {"current-context": "", "contexts": {}}
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    data.setdefault("current-context", "")
+    data.setdefault("contexts", {})
+    return data
+
+
+def save_config(config: Dict[str, Any]) -> None:
+    path = get_config_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+
+def get_context(config: Dict[str, Any], name: str) -> Optional[Dict[str, Any]]:
+    return config.get("contexts", {}).get(name)
+
+
+def get_current_context_name(config: Dict[str, Any]) -> str:
+    return config.get("current-context", "")
+
+
+def get_current_context(config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    name = get_current_context_name(config)
+    if not name:
+        return None
+    return get_context(config, name)
+
+
+def set_context(config: Dict[str, Any], name: str, values: Dict[str, Any]) -> Dict[str, Any]:
+    """Create or update a context, merging with existing values."""
+    contexts = config.setdefault("contexts", {})
+    existing = contexts.get(name, {})
+    existing.update({k: v for k, v in values.items() if v is not None})
+    contexts[name] = existing
+    return config
+
+
+def delete_context(config: Dict[str, Any], name: str) -> Dict[str, Any]:
+    contexts = config.get("contexts", {})
+    if name not in contexts:
+        raise ValueError(f"context '{name}' not found")
+    del contexts[name]
+    if config.get("current-context") == name:
+        config["current-context"] = ""
+    return config
+
+
+def use_context(config: Dict[str, Any], name: str) -> Dict[str, Any]:
+    if name not in config.get("contexts", {}):
+        raise ValueError(f"context '{name}' not found")
+    config["current-context"] = name
+    return config

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import os
 
-VERSION = "0.4"
+VERSION = "0.5"
 
 
 def get_long_description():
@@ -34,6 +34,8 @@ setup(
     install_requires=[
         "click",
         "azure-eventhub==5.14.0",
+        "azure-identity",
+        "pyyaml",
     ],
     extras_require={
         "test": ["pytest"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,197 @@
+import os
+import tempfile
+
+import pytest
+from click.testing import CliRunner
+
+from eventhubs.cli import cli
+from eventhubs.config import load_config, save_config
+
+
+@pytest.fixture(autouse=True)
+def isolated_config(monkeypatch, tmp_path):
+    """Point config to a temp directory so tests don't touch real config."""
+    config_path = str(tmp_path / "config.yaml")
+    monkeypatch.setenv("EVENTHUB_CONFIG", config_path)
+    return config_path
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+class TestConfigSetContext:
+    def test_create_context_with_credential(self, runner):
+        result = runner.invoke(cli, [
+            "config", "set-context", "dev",
+            "--fully-qualified-namespace", "dev.servicebus.windows.net",
+            "--eventhub-name", "events",
+            "--credential", "default",
+        ])
+        assert result.exit_code == 0
+        assert "Context 'dev' updated." in result.output
+
+        cfg = load_config()
+        ctx = cfg["contexts"]["dev"]
+        assert ctx["fully-qualified-namespace"] == "dev.servicebus.windows.net"
+        assert ctx["eventhub-name"] == "events"
+        assert ctx["credential"] == "default"
+
+    def test_create_context_with_connection_string(self, runner):
+        result = runner.invoke(cli, [
+            "config", "set-context", "prod",
+            "--connection-string", "Endpoint=sb://prod.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=val",
+            "--eventhub-name", "telemetry",
+        ])
+        assert result.exit_code == 0
+
+        cfg = load_config()
+        ctx = cfg["contexts"]["prod"]
+        assert ctx["connection-string"].startswith("Endpoint=")
+        assert ctx["eventhub-name"] == "telemetry"
+
+    def test_update_existing_context_merges(self, runner):
+        runner.invoke(cli, [
+            "config", "set-context", "dev",
+            "--fully-qualified-namespace", "dev.servicebus.windows.net",
+            "--credential", "default",
+            "--eventhub-name", "events",
+        ])
+        runner.invoke(cli, [
+            "config", "set-context", "dev",
+            "--consumer-group", "processors",
+        ])
+
+        cfg = load_config()
+        ctx = cfg["contexts"]["dev"]
+        assert ctx["fully-qualified-namespace"] == "dev.servicebus.windows.net"
+        assert ctx["consumer-group"] == "processors"
+
+
+class TestConfigGetContexts:
+    def test_empty(self, runner):
+        result = runner.invoke(cli, ["config", "get-contexts"])
+        assert result.exit_code == 0
+        assert "No contexts configured." in result.output
+
+    def test_lists_contexts(self, runner):
+        runner.invoke(cli, [
+            "config", "set-context", "a",
+            "--fully-qualified-namespace", "a.servicebus.windows.net",
+            "--credential", "azurecli",
+            "--eventhub-name", "hub-a",
+        ])
+        runner.invoke(cli, [
+            "config", "set-context", "b",
+            "--connection-string", "Endpoint=sb://b/",
+            "--eventhub-name", "hub-b",
+        ])
+
+        result = runner.invoke(cli, ["config", "get-contexts"])
+        assert result.exit_code == 0
+        assert "a" in result.output
+        assert "b" in result.output
+        assert "azurecli@a.servicebus.windows.net" in result.output
+        assert "connection-string" in result.output
+
+
+class TestConfigUseContext:
+    def test_switch_context(self, runner):
+        runner.invoke(cli, [
+            "config", "set-context", "dev",
+            "--fully-qualified-namespace", "dev.servicebus.windows.net",
+            "--credential", "default",
+            "--eventhub-name", "events",
+        ])
+
+        result = runner.invoke(cli, ["config", "use-context", "dev"])
+        assert result.exit_code == 0
+        assert "Switched to context 'dev'" in result.output
+
+        result = runner.invoke(cli, ["config", "current-context"])
+        assert result.exit_code == 0
+        assert result.output.strip() == "dev"
+
+    def test_use_nonexistent_context_fails(self, runner):
+        result = runner.invoke(cli, ["config", "use-context", "nope"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+
+class TestConfigDeleteContext:
+    def test_delete_existing(self, runner):
+        runner.invoke(cli, [
+            "config", "set-context", "temp",
+            "--connection-string", "Endpoint=sb://temp/",
+            "--eventhub-name", "hub",
+        ])
+        result = runner.invoke(cli, ["config", "delete-context", "temp"])
+        assert result.exit_code == 0
+        assert "deleted" in result.output
+
+        cfg = load_config()
+        assert "temp" not in cfg["contexts"]
+
+    def test_delete_current_clears_current(self, runner):
+        runner.invoke(cli, [
+            "config", "set-context", "temp",
+            "--connection-string", "Endpoint=sb://temp/",
+            "--eventhub-name", "hub",
+        ])
+        runner.invoke(cli, ["config", "use-context", "temp"])
+        runner.invoke(cli, ["config", "delete-context", "temp"])
+
+        cfg = load_config()
+        assert cfg["current-context"] == ""
+
+    def test_delete_nonexistent_fails(self, runner):
+        result = runner.invoke(cli, ["config", "delete-context", "nope"])
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+
+class TestConfigCurrentContext:
+    def test_no_current(self, runner):
+        result = runner.invoke(cli, ["config", "current-context"])
+        assert result.exit_code == 0
+        assert "No current context is set." in result.output
+
+
+class TestSettingsResolution:
+    def test_connection_string_flag_still_works(self, runner):
+        """Backward compat: --connection-string + --name works without config."""
+        result = runner.invoke(cli, [
+            "--connection-string", "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=k;SharedAccessKey=v",
+            "--name", "hub",
+            "events", "--help",
+        ])
+        assert result.exit_code == 0
+
+    def test_requires_some_auth(self, runner):
+        result = runner.invoke(cli, [
+            "--name", "hub",
+            "events", "--help",
+        ])
+        assert result.exit_code != 0
+        assert "either --connection-string or --fully-qualified-namespace" in result.output
+
+    def test_mutual_exclusion(self, runner):
+        result = runner.invoke(cli, [
+            "--connection-string", "Endpoint=sb://test/;SharedAccessKeyName=k;SharedAccessKey=v",
+            "--fully-qualified-namespace", "test.servicebus.windows.net",
+            "--credential", "default",
+            "--name", "hub",
+            "events", "--help",
+        ])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+
+    def test_credential_required_with_fqns(self, runner):
+        result = runner.invoke(cli, [
+            "--fully-qualified-namespace", "test.servicebus.windows.net",
+            "--name", "hub",
+            "events", "--help",
+        ])
+        assert result.exit_code != 0
+        assert "--credential is required" in result.output


### PR DESCRIPTION
## Summary

- **Token-based authentication**: authenticate with `--fully-qualified-namespace` and `--credential` using `azure-identity` (supports `default`, `azurecli`, `environment`, `managedidentity`), as an alternative to connection strings.
- **Config file with named contexts**: kubectl-style YAML config (`~/.config/eventhubs/config.yaml`) so connection details no longer need to be passed on every invocation. New `config` subcommands: `set-context`, `use-context`, `get-contexts`, `current-context`, `delete-context`.
- **CLI renames**: `eventdata` group → `events`, `send-event` command → `send`.
- **Migration guide**: added `MIGRATION-0.4-to-0.5.md` for existing v0.4 users.

### Breaking changes

| v0.4 | v0.5 |
|------|------|
| `eh eventdata receive` | `eh events receive` |
| `eh eventdata send-event` | `eh events send` |
| `eh eventdata send-batch` | `eh events send-batch` |

### New dependencies

- `azure-identity`
- `pyyaml`

## Test plan

- [ ] Verify `eh events receive` works with a connection string
- [ ] Verify `eh events send --text '...'` works with a connection string
- [ ] Verify `eh events send-batch` works with a connection string
- [ ] Verify token-based auth with `--fully-qualified-namespace` and `--credential default`
- [ ] Verify `config set-context`, `use-context`, `get-contexts`, `current-context`, `delete-context`
- [ ] Verify CLI flag / env var overrides take precedence over config context values
- [ ] Run `pytest` (config unit tests)


Made with [Cursor](https://cursor.com)